### PR TITLE
Añadir componente de Mapa de Parcelas con vista de acordeón y tarjetas

### DIFF
--- a/src/app/parcelas-mobile-demo/page.tsx
+++ b/src/app/parcelas-mobile-demo/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useState } from 'react';
+import Image from 'next/image';
+import MapaParcellasPhoneL_Accordion from '@/components/MapaParcelas/MapaParcellasPhoneL_Accordion';
+import MapaParcellasPhoneL_Cards from '@/components/MapaParcelas/MapaParcellasPhoneL_Cards';
+
+export default function page() {
+  const [activeView, setActiveView] = useState<'accordion' | 'cards'>('accordion');
+
+  return (
+    <div className="w-full min-h-screen flex flex-col bg-gray-50">
+      {/* Tabs */}
+      <div className="fixed top-0 z-1000 bg-white border-b border-gray-200 shadow-sm z-10   ">
+        <div className="max-w-4xl mx-auto px-4 py-3 flex gap-4">
+          <button
+            onClick={() => setActiveView('accordion')}
+            className={`px-4 py-2 rounded font-semibold transition-all ${
+              activeView === 'accordion'
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            📑 Acordeón
+          </button>
+          <button
+            onClick={() => setActiveView('cards')}
+            className={`px-4 py-2 rounded font-semibold transition-all ${
+              activeView === 'cards'
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            🎴 Tarjetas
+          </button>
+          <div className="ml-auto text-sm text-gray-600 py-2">
+            <span className="bg-yellow-100 px-2 py-1 rounded">Mobile L (480px-639px)</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1">
+        <Image src="/fincas_air.png" alt="fincas Air" width={200} height={200} className="w-full" />
+        {activeView === 'accordion' && <MapaParcellasPhoneL_Accordion />}
+        {activeView === 'cards' && <MapaParcellasPhoneL_Cards />}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -14,7 +14,7 @@ export default function Header() {
     }
 
     return (
-        <header className="w-full h-24 gap-6 bg-white/70 lg:bg-white/50 fixed top-0 z-50 backdrop-blur-md shadow-md">
+        <header className="w-full h-24 gap-6 bg-white/70 lg:bg-white/50 sticky top-0 z-50 backdrop-blur-md shadow-md">
             <WebHeader onLogoClickFunction={redirectToHome} />
             <MobileHeader />
         </header>

--- a/src/components/MapaParcelas/MapaParcellasPhoneL_Accordion.tsx
+++ b/src/components/MapaParcelas/MapaParcellasPhoneL_Accordion.tsx
@@ -1,0 +1,126 @@
+'use client';
+import { useState } from 'react';
+import { PARCELAS_SECTOR_A, PARCELAS_SECTOR_B, PARCELAS_SECTOR_C, PARCELAS_SECTOR_D, PARCELAS_SECTOR_E, PARCELAS_SECTOR_F, PARCELAS_SECTOR_G, PARCELAS_SECTOR_H, ParcelaData } from "@/assets/data/parcelas";
+
+const SECTORES = [
+  { id: 'A', label: 'Sector A (Frac. 1)', data: PARCELAS_SECTOR_A },
+  { id: 'B', label: 'Sector B (Frac. 1)', data: PARCELAS_SECTOR_B },
+  { id: 'C', label: 'Sector C (Frac. 1)', data: PARCELAS_SECTOR_C },
+  { id: 'D', label: 'Sector D (Frac. 1)', data: PARCELAS_SECTOR_D },
+  { id: 'E', label: 'Sector E (Frac. 2)', data: PARCELAS_SECTOR_E },
+  { id: 'F', label: 'Sector F (Frac. 2)', data: PARCELAS_SECTOR_F },
+  { id: 'G', label: 'Sector G (Frac. 2)', data: PARCELAS_SECTOR_G },
+  { id: 'H', label: 'Sector H (Frac. 2)', data: PARCELAS_SECTOR_H },
+];
+
+export default function MapaParcellasPhoneL_Accordion() {
+  const [expandedSector, setExpandedSector] = useState<string | null>('A');
+
+  return (
+    <div className="w-full bg-gradient-to-b from-gray-50 to-gray-100 min-h-screen p-4">
+      <div className="max-w-md mx-auto">
+        <h1 className="text-2xl font-bold text-gray-800 mb-2">Mapa de Parcelas</h1>
+        <p className="text-sm text-gray-600 mb-6">Clic en un sector para ver sus parcelas</p>
+        
+        <div className="space-y-2">
+          {SECTORES.map((sector) => (
+            <SectorAccordion
+              key={sector.id}
+              sector={sector}
+              isExpanded={expandedSector === sector.id}
+              onToggle={() => setExpandedSector(expandedSector === sector.id ? null : sector.id)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SectorAccordion({ 
+  sector, 
+  isExpanded, 
+  onToggle 
+}: { 
+  sector: typeof SECTORES[0]; 
+  isExpanded: boolean; 
+  onToggle: () => void;
+}) {
+  const allParcelas = [
+    ...sector.data.izquierda,
+    ...sector.data.derecha,
+    ...(sector.data.center || [])
+  ];
+
+  const vendidas = allParcelas.filter(p => p.status === 'Vendido').length;
+  const disponibles = allParcelas.filter(p => p.status === 'Disponible').length;
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden bg-white shadow-sm">
+      <button
+        onClick={onToggle}
+        className="w-full px-4 py-3 flex items-center justify-between bg-gray-50 hover:bg-gray-100 transition-colors"
+      >
+        <div className="text-left">
+          <h3 className="font-semibold text-gray-900">{sector.label}</h3>
+          <p className="text-xs text-gray-600 mt-1">
+            {disponibles} disponible{disponibles !== 1 ? 's' : ''} • {vendidas} vendida{vendidas !== 1 ? 's' : ''}
+          </p>
+        </div>
+        <svg
+          className={`w-5 h-5 text-gray-600 transition-transform ${
+            isExpanded ? 'rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+        </svg>
+      </button>
+
+      {isExpanded && (
+        <div className="px-4 py-4 border-t border-gray-100 max-h-96 overflow-y-auto">
+          <div className="grid grid-cols-1 gap-2">
+            {allParcelas.map((parcela, idx) => (
+              <ParcelaCard key={idx} parcela={parcela} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ParcelaCard({ parcela }: { parcela: any }) {
+  const isVendido = parcela.status === 'Vendido';
+  
+  return (
+    <div
+      className={`p-3 rounded border-l-4 ${
+        isVendido
+          ? 'bg-yellow-50 border-yellow-400'
+          : 'bg-green-50 border-green-400'
+      }`}
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="font-bold text-lg text-gray-900">Parcela {parcela.numero}</p>
+          <div className="mt-2 space-y-1">
+            <p className="text-sm text-gray-700">
+              <span className="font-semibold">Área:</span> {parcela.metrosCuadrados} M²
+            </p>
+            <p className="text-sm text-gray-700">
+              <span className="font-semibold">Fracción:</span> {parcela.fraccion}
+            </p>
+            <p className={`text-sm font-semibold ${
+              isVendido ? 'text-yellow-700' : 'text-green-700'
+            }`}>
+              {parcela.status === 'Vendido' ? '✓ VENDIDO' : '◆ Disponible'}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/MapaParcelas/MapaParcellasPhoneL_Cards.tsx
+++ b/src/components/MapaParcelas/MapaParcellasPhoneL_Cards.tsx
@@ -1,0 +1,190 @@
+'use client';
+import { useState } from 'react';
+import { PARCELAS_SECTOR_A, PARCELAS_SECTOR_B, PARCELAS_SECTOR_C, PARCELAS_SECTOR_D, PARCELAS_SECTOR_E, PARCELAS_SECTOR_F, PARCELAS_SECTOR_G, PARCELAS_SECTOR_H, ParcelaData } from "@/assets/data/parcelas";
+
+const SECTORES = [
+  { id: 'A', label: 'Sector A', fraccion: 1, data: PARCELAS_SECTOR_A },
+  { id: 'B', label: 'Sector B', fraccion: 1, data: PARCELAS_SECTOR_B },
+  { id: 'C', label: 'Sector C', fraccion: 1, data: PARCELAS_SECTOR_C },
+  { id: 'D', label: 'Sector D', fraccion: 1, data: PARCELAS_SECTOR_D },
+  { id: 'E', label: 'Sector E', fraccion: 2, data: PARCELAS_SECTOR_E },
+  { id: 'F', label: 'Sector F', fraccion: 2, data: PARCELAS_SECTOR_F },
+  { id: 'G', label: 'Sector G', fraccion: 2, data: PARCELAS_SECTOR_G },
+  { id: 'H', label: 'Sector H', fraccion: 2, data: PARCELAS_SECTOR_H },
+];
+
+export default function MapaParcellasPhoneL_Cards() {
+  const [selectedFraccion, setSelectedFraccion] = useState<1 | 2 | null>(null);
+  const [statusFilter, setStatusFilter] = useState<'todos' | 'disponibles' | 'vendidos'>('todos');
+
+  const filteredSectores = SECTORES.filter(s => 
+    selectedFraccion === null || s.fraccion === selectedFraccion
+  );
+
+  const allParcelas = filteredSectores.flatMap(s => [
+    ...s.data.izquierda,
+    ...s.data.derecha,
+    ...(s.data.center || [])
+  ]).filter(p => {
+    if (statusFilter === 'disponibles') return p.status === 'Disponible';
+    if (statusFilter === 'vendidos') return p.status === 'Vendido';
+    return true;
+  });
+
+  const stats = {
+    total: allParcelas.length,
+    vendidas: allParcelas.filter(p => p.status === 'Vendido').length,
+    disponibles: allParcelas.filter(p => p.status === 'Disponible').length,
+  };
+
+  return (
+    <div className="w-full bg-gradient-to-b from-gray-50 to-gray-100 min-h-screen p-4">
+      <div className="max-w-lg mx-auto">
+        <h1 className="text-2xl font-bold text-gray-800 mb-6">Mapa de Parcelas</h1>
+
+        {/* Stats */}
+        <div className="grid grid-cols-3 gap-2 mb-6">
+          <div className="bg-blue-50 rounded-lg p-3 border border-blue-200">
+            <p className="text-2xl font-bold text-blue-900">{stats.total}</p>
+            <p className="text-xs text-blue-700">Total</p>
+          </div>
+          <div className="bg-green-50 rounded-lg p-3 border border-green-200">
+            <p className="text-2xl font-bold text-green-900">{stats.disponibles}</p>
+            <p className="text-xs text-green-700">Disponibles</p>
+          </div>
+          <div className="bg-yellow-50 rounded-lg p-3 border border-yellow-200">
+            <p className="text-2xl font-bold text-yellow-900">{stats.vendidas}</p>
+            <p className="text-xs text-yellow-700">Vendidas</p>
+          </div>
+        </div>
+
+        {/* Filters */}
+        <div className="mb-6 space-y-3">
+          {/* Fracción Filter */}
+          <div>
+            <p className="text-sm font-semibold text-gray-700 mb-2">Fracción</p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setSelectedFraccion(null)}
+                className={`flex-1 py-2 px-3 rounded font-medium transition-all ${
+                  selectedFraccion === null
+                    ? 'bg-gray-900 text-white'
+                    : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50'
+                }`}
+              >
+                Todas
+              </button>
+              <button
+                onClick={() => setSelectedFraccion(1)}
+                className={`flex-1 py-2 px-3 rounded font-medium transition-all ${
+                  selectedFraccion === 1
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50'
+                }`}
+              >
+                Frac. 1
+              </button>
+              <button
+                onClick={() => setSelectedFraccion(2)}
+                className={`flex-1 py-2 px-3 rounded font-medium transition-all ${
+                  selectedFraccion === 2
+                    ? 'bg-purple-600 text-white'
+                    : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50'
+                }`}
+              >
+                Frac. 2
+              </button>
+            </div>
+          </div>
+
+          {/* Status Filter */}
+          <div>
+            <p className="text-sm font-semibold text-gray-700 mb-2">Estado</p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setStatusFilter('todos')}
+                className={`flex-1 py-2 px-3 rounded font-medium text-sm transition-all ${
+                  statusFilter === 'todos'
+                    ? 'bg-gray-900 text-white'
+                    : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50'
+                }`}
+              >
+                Todos
+              </button>
+              <button
+                onClick={() => setStatusFilter('disponibles')}
+                className={`flex-1 py-2 px-3 rounded font-medium text-sm transition-all ${
+                  statusFilter === 'disponibles'
+                    ? 'bg-green-600 text-white'
+                    : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50'
+                }`}
+              >
+                Disponibles
+              </button>
+              <button
+                onClick={() => setStatusFilter('vendidos')}
+                className={`flex-1 py-2 px-3 rounded font-medium text-sm transition-all ${
+                  statusFilter === 'vendidos'
+                    ? 'bg-yellow-600 text-white'
+                    : 'bg-white text-gray-700 border border-gray-200 hover:bg-gray-50'
+                }`}
+              >
+                Vendidos
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Parcelas Grid */}
+        <div className="grid grid-cols-2 gap-3">
+          {allParcelas.map((parcela, idx) => (
+            <ParcelaCard key={idx} parcela={parcela} />
+          ))}
+        </div>
+
+        {allParcelas.length === 0 && (
+          <div className="text-center py-12">
+            <p className="text-gray-500 text-sm">No hay parcelas que coincidan con los filtros</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ParcelaCard({ parcela }: { parcela: any }) {
+  const isVendido = parcela.status === 'Vendido';
+  
+  return (
+    <div
+      className={`p-3 rounded-lg border-2 transition-all hover:shadow-md cursor-pointer ${
+        isVendido
+          ? 'bg-yellow-50 border-yellow-300 hover:bg-yellow-100'
+          : 'bg-green-50 border-green-300 hover:bg-green-100'
+      }`}
+    >
+      <div className="space-y-2">
+        <p className="font-bold text-base text-gray-900">#{parcela.numero}</p>
+        
+        <div className="space-y-1 text-xs">
+          <div className="flex justify-between">
+            <span className="text-gray-600">Área:</span>
+            <span className="font-semibold text-gray-900">{parcela.metrosCuadrados} M²</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-600">Frac:</span>
+            <span className="font-semibold text-gray-900">{parcela.fraccion}</span>
+          </div>
+        </div>
+
+        <div className={`pt-2 border-t text-center font-semibold text-xs rounded ${
+          isVendido
+            ? 'text-yellow-700 bg-yellow-100'
+            : 'text-green-700 bg-green-100'
+        }`}>
+          {isVendido ? 'VENDIDO' : 'DISPONIBLE'}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implementar un nuevo componente que permite visualizar parcelas en dos formatos: acordeón y tarjetas, con opciones de filtrado por fracción y estado. Se realizaron ajustes en el encabezado para mejorar la navegación.